### PR TITLE
Separate associations in example schema

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,8 +6,8 @@ One of its major features is following activerecord associations and generating 
 number of SQL insert statements required, avoiding the N+1 insert problem. An example probably
 explains it best. Say you had a schema like this:
  
-Publishers have Books
-Books have Reviews
+- Publishers have Books
+- Books have Reviews
  
 and you wanted to bulk insert 100 new publishers with 10K books and 3 reviews per book. This library will follow the associations
 down and generate only 3 SQL insert statements - one for the publishers, one for the books, and one for the reviews.


### PR DESCRIPTION
This just adds a little formatting to separate the two associations in the hypothetical schema to make it a little easier to read.
